### PR TITLE
Revert "chore(deps): bump org.junit:junit-bom from 5.13.4 to 6.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <!-- Since Aruqillian core 1.9.0.Final, need to add Aruqillian Jakarta BOM which aligns to Jakarta EE -->
     	<arquillian-jakarta-bom.version>10.0.0.Final</arquillian-jakarta-bom.version>
     	<shrinkwrap-resolver-bom.version>3.3.4</shrinkwrap-resolver-bom.version>
-        <junit-bom.version>6.0.0</junit-bom.version>
+        <junit-bom.version>5.13.4</junit-bom.version>
         <mockito-bom.version>5.20.0</mockito-bom.version>
         <awaitility.version>4.3.0</awaitility.version>
         <hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
### **User description**
Reverts hantsy/jakartaee-rest-sample#397


___

### **PR Type**
Other


___

### **Description**
- Reverts JUnit BOM version from 6.0.0 back to 5.13.4


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JUnit BOM 6.0.0"] -- "revert" --> B["JUnit BOM 5.13.4"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Revert JUnit BOM version to 5.13.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml

- Reverts `junit-bom.version` property from 6.0.0 to 5.13.4


</details>


  </td>
  <td><a href="https://github.com/hantsy/jakartaee-rest-sample/pull/399/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

